### PR TITLE
move fileAccessProperties() definition to cpp file

### DIFF
--- a/hep_hpc/hdf5/Ntuple.cpp
+++ b/hep_hpc/hdf5/Ntuple.cpp
@@ -23,3 +23,13 @@ hep_hpc::hdf5::NtupleDetail::verifiedFile(File file)
   }
   return file;
 }
+
+hep_hpc::hdf5::PropertyList
+hep_hpc::hdf5::NtupleDetail::fileAccessProperties()
+{
+  // Ensure we are using the latest available HDF5 file format to
+  // write our data.
+  PropertyList plist(H5P_FILE_ACCESS);
+  H5Pset_libver_bounds(plist, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
+  return plist;
+}

--- a/hep_hpc/hdf5/Ntuple.hpp
+++ b/hep_hpc/hdf5/Ntuple.hpp
@@ -361,7 +361,7 @@ namespace hep_hpc {
                        Dataset & dset,
                        COL const & col);
 
-      PropertyList fileAccessProperties()
+      static PropertyList fileAccessProperties()
       {
         // Ensure we are using the latest available HDF5 file format to
         // write our data.

--- a/hep_hpc/hdf5/Ntuple.hpp
+++ b/hep_hpc/hdf5/Ntuple.hpp
@@ -361,14 +361,7 @@ namespace hep_hpc {
                        Dataset & dset,
                        COL const & col);
 
-      static PropertyList fileAccessProperties()
-      {
-        // Ensure we are using the latest available HDF5 file format to
-        // write our data.
-        PropertyList plist(H5P_FILE_ACCESS);
-        H5Pset_libver_bounds(plist, H5F_LIBVER_LATEST, H5F_LIBVER_LATEST);
-        return plist;
-      }
+      PropertyList fileAccessProperties();
 
     } // Namespace NtupleDetail.
   } // Namespace hdf5.


### PR DESCRIPTION
the `fileAccessProperties()` function in `Ntuple.hpp` is both declared and defined in this header, which can lead to errors of the form

```
CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/Neutrino.cxx.o: In function `hep_hpc::hdf5::NtupleDetail::fileAccessProperties()':
/cvmfs/larsoft.opensciencegrid.org/products/hep_hpc/v0_14_02/Linux64bit+3.10-2.17-e26-prof/include/hep_hpc/hdf5/errorHandling.hpp:353: multiple definition of `hep_hpc::hdf5::NtupleDetail::fileAccessProperties()'
CMakeFiles/larrecodnn_HDF5Maker_Tables.dir/Event.cxx.o:/cvmfs/larsoft.opensciencegrid.org/products/hep_hpc/v0_14_02/Linux64bit+3.10-2.17-e26-prof/include/hep_hpc/hdf5/Ntuple.hpp:365: first defined here
collect2: error: ld returned 1 exit status
```

this PR adds the `static` keyword to this function, ensuring that it's only defined once.