### PR TITLE
Fix compiler-dependent destructor qualification issue

### DIFF
--- a/hep_hpc/CMakeLists.txt
+++ b/hep_hpc/CMakeLists.txt
@@ -1,3 +1,18 @@
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles("
+template <typename T>
+struct A {
+  ~A();
+};
+
+template <typename T>
+A<T>::~A<T>() {}
+
+int main() {
+  A<int> a;
+}
+" HEP_HPC_QUALIFY_DESTRUCTOR_NAMES)
+
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/detail/config.hpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/detail/config.hpp
   @ONLY)

--- a/hep_hpc/CMakeLists.txt
+++ b/hep_hpc/CMakeLists.txt
@@ -1,4 +1,7 @@
 include(CheckCXXSourceCompiles)
+# Propagate the project's warning/error flags so the probe matches real build
+# conditions (-Wall -Wextra -Werror -pedantic are set via add_compile_options).
+set(CMAKE_REQUIRED_FLAGS "-Wall -Wextra -Werror -pedantic")
 check_cxx_source_compiles("
 template <typename T>
 struct A {
@@ -9,9 +12,11 @@ template <typename T>
 A<T>::~A<T>() {}
 
 int main() {
-  A<int> a;
+  (void)A<int>{};
+  return 0;
 }
 " HEP_HPC_QUALIFY_DESTRUCTOR_NAMES)
+unset(CMAKE_REQUIRED_FLAGS)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/detail/config.hpp.in
   ${CMAKE_CURRENT_BINARY_DIR}/detail/config.hpp

--- a/hep_hpc/Utilities/SimpleRAII.hpp
+++ b/hep_hpc/Utilities/SimpleRAII.hpp
@@ -57,6 +57,8 @@
 //
 ////////////////////////////////////////////////////////////////////////
 
+#include "hep_hpc/Utilities/detail/compiler_macros.hpp"
+
 #include <functional>
 #include <utility>
 
@@ -319,7 +321,7 @@ reset(RH rh, TEARDOWN_FUNC teardown)
 template <typename RH>
 inline
 hep_hpc::detail::SimpleRAII<RH>::
-~SimpleRAII<RH>() noexcept(false)
+~HEP_HPC_DTOR(SimpleRAII, RH)() noexcept(false)
 {
   if (teardown_) {
     teardown_(std::move(resourceHandle_));
@@ -414,7 +416,7 @@ reset(TEARDOWN_FUNC teardown)
 // Destructor.
 inline
 hep_hpc::detail::SimpleRAII<void>::
-~SimpleRAII<void>() noexcept(false)
+~HEP_HPC_DTOR(SimpleRAII, void)() noexcept(false)
 {
   if (teardown_) {
     teardown_();

--- a/hep_hpc/Utilities/detail/compiler_macros.hpp
+++ b/hep_hpc/Utilities/detail/compiler_macros.hpp
@@ -1,6 +1,8 @@
 #ifndef hep_hpc_Utilities_detail_compiler_macros_hpp
 #define hep_hpc_Utilities_detail_compiler_macros_hpp
 
+#include "hep_hpc/detail/config.hpp"
+
 ////////////////////////////////////////////////////////////////////////
 // Define GCC and Clang version tests:
 ////////////////////////////////////////////////////////////////////////
@@ -129,6 +131,17 @@
 #else
 #define UNUSED_PRIVATE_FIELD
 #endif
+#endif
+
+////////////////////////////////////////////////////////////////////////
+// Define HEP_HPC_DTOR(NAME, ...) to allow for optional template
+// arguments in destructor definitions.
+////////////////////////////////////////////////////////////////////////
+
+#ifdef HEP_HPC_QUALIFY_DESTRUCTOR_NAMES
+#define HEP_HPC_DTOR(NAME, ...) NAME<__VA_ARGS__>
+#else
+#define HEP_HPC_DTOR(NAME, ...) NAME
 #endif
 
 #endif /* hep_hpc_Utilities_detail_compiler_macros_hpp */

--- a/hep_hpc/detail/config.hpp.in
+++ b/hep_hpc/detail/config.hpp.in
@@ -2,4 +2,5 @@
 #define hep_hpc_detail_config_hpp_in
 #cmakedefine HEP_HPC_USE_BOOST_INDEX_SEQUENCE
 #cmakedefine HEP_HPC_USE_MPI
+#cmakedefine HEP_HPC_QUALIFY_DESTRUCTOR_NAMES
 #endif /* hep_hpc_detail_config_hpp_in */

--- a/hep_hpc/hdf5/Ntuple.hpp
+++ b/hep_hpc/hdf5/Ntuple.hpp
@@ -531,7 +531,7 @@ Ntuple(File file,
 }
 
 template <typename... Args>
-hep_hpc::hdf5::Ntuple<Args...>::~Ntuple<Args...>() noexcept
+hep_hpc::hdf5::Ntuple<Args...>::~HEP_HPC_DTOR(Ntuple, Args...)() noexcept
 {
   ScopedErrorHandler seh(ErrorMode::HDF5_DEFAULT);
   if (flush_(iSequence()) != 0) {


### PR DESCRIPTION
I have resolved the issue where some compilers/standards require destructor definitions to be qualified with template arguments while others forbid it.

The solution involves:
1.  A new CMake check in `hep_hpc/CMakeLists.txt` using `check_cxx_source_compiles` to detect if the compiler allows qualified destructor names (e.g., `~A<T>()`).
2.  A new `cmakedefine` in `hep_hpc/detail/config.hpp.in` called `HEP_HPC_QUALIFY_DESTRUCTOR_NAMES`.
3.  A helper macro `HEP_HPC_DTOR(NAME, ...)` in `hep_hpc/Utilities/detail/compiler_macros.hpp` that expands to the appropriate syntax based on the CMake check.
4.  Updating `hep_hpc/Utilities/SimpleRAII.hpp` and `hep_hpc/hdf5/Ntuple.hpp` to use the `HEP_HPC_DTOR` macro in their destructor definitions.

I verified the logic using standalone C++ scripts simulating the different compiler behaviors and standards (C++17 vs C++20). I also ensured that all temporary files were removed and that the necessary headers are included.

---
*PR created automatically by Jules for task [12844763402342853339](https://jules.google.com/task/12844763402342853339) started by @greenc-FNAL*